### PR TITLE
[HOTFIX] keeping track of older images tags

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -45,7 +45,10 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }},${{ env.IMAGE_NAME }}:latest,${{ env.IMAGE_NAME }}:${{ steps.generate_version.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.generate_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -63,7 +66,7 @@ jobs:
             --form token=${{ secrets.GITLAB_CI_TOKEN }} \
             --form ref=main \
             --form 'variables[pipeline_name]=${{ github.event.repository.name }} - ${{ needs.build-and-push.outputs.commit_title }}' \
-            --form 'variables[docker_image_tag]=latest' \
+            --form 'variables[docker_image_tag]=${{ needs.build-and-push.outputs.version }}' \
             --form 'variables[application_to_deploy]=${{ github.event.repository.name }}' \
             --form 'variables[deployment_environment]=dev' \
             'https://gitlab.com/api/v4/projects/58117805/trigger/pipeline')"


### PR DESCRIPTION
We used to get the docker image tag set only for the latest version build, but when building new images, older ones used to lose their tag, leading to messy images tags tracking over time.

Exemple:
<img width="1840" alt="Screenshot 2025-04-25 at 12 40 48" src="https://github.com/user-attachments/assets/f1fe1491-c19c-48d6-bc5e-4c889556e2cd" />

### Changes made

It now should deploys the specific version that was built in the previous job (using the date-based versioning format from `generate_version step`). This ensures we're deploying the exact version that was just tested/built rather than whatever happens to have the latest tag.

The workflow correctly applies all three tags to the current build, while older builds retain their SHA and version tags.
