### PR TITLE
fix(frontend): :lipstick: Fix message input outline

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -510,7 +510,7 @@
 							}}
 						>
 							<div
-								class="flex-1 flex flex-col relative w-full rounded-3xl px-1 fr-background-contrast--grey dark:text-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500"
+								class="flex-1 flex flex-col relative w-full rounded-3xl px-1 fr-background-contrast--grey dark:text-gray-100 focus-within:outline-2  focus-within:outline-blue-500 z-50"
 								dir={$settings?.chatDirection ?? 'auto'}
 							>
 								{#if files.length > 0}


### PR DESCRIPTION
### Description

Fix outline offset creating a gap between the text input and the outline, when scrolling we can see text passing in this gap which is not optimal.  

Z-index of message input is lower than the user's input chat bubble, which makes the chat bubble go on top of the outline

### Changed

- Remove outline offset from user message input
- Increase user message input z index to be on top of user's message chat bubble

