### PR TITLE
fix: force light mode

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -323,7 +323,8 @@
 			<div class="">
 				<div class=" mb-1 text-sm font-medium">{i18nInstance?.t('WebUI Settings')}</div>
 
-				<div class="flex w-full justify-between">
+				<!-- https://linear.app/albert-conversation/issue/ALB-149/desactiver-totalement-le-theme-dark-dans-openwebui-le-temps-de-fixer -->
+				<!-- <div class="flex w-full justify-between">
 					<div class=" self-center text-xs font-medium">{i18nInstance?.t('Theme')}</div>
 					<div class="flex items-center relative">
 						<select
@@ -337,7 +338,7 @@
 							<option value="light">☀️ {i18nInstance?.t('Light')}</option>
 						</select>
 					</div>
-				</div>
+				</div> -->
 
 				<div class=" flex w-full justify-between">
 					<div class=" self-center text-xs font-medium">{i18nInstance?.t('Language')}</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,20 @@
 		stiffness: 0.05
 	});
 
+	// Set theme immediately
+	theme.set('light');
+	localStorage.setItem('theme', 'light');
+	
+	// Apply theme to DOM immediately
+	if (typeof document !== 'undefined') {
+		document.documentElement.setAttribute('theme', 'light');
+		
+		const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+		if (metaThemeColor) {
+			metaThemeColor.setAttribute('content', '#ffffff');
+		}
+	}
+
 	import { onMount, tick, setContext } from 'svelte';
 	import {
 		config,
@@ -714,13 +728,7 @@
 {/if}
 
 <Toaster
-	theme={$theme.includes('dark')
-		? 'dark'
-		: $theme === 'system'
-			? window.matchMedia('(prefers-color-scheme: dark)').matches
-				? 'dark'
-				: 'light'
-			: 'light'}
+	theme={'light'}
 	richColors
 	position="top-right"
 />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,11 +10,11 @@
 	// Set theme immediately
 	theme.set('light');
 	localStorage.setItem('theme', 'light');
-	
+
 	// Apply theme to DOM immediately
 	if (typeof document !== 'undefined') {
 		document.documentElement.setAttribute('theme', 'light');
-		
+
 		const metaThemeColor = document.querySelector('meta[name="theme-color"]');
 		if (metaThemeColor) {
 			metaThemeColor.setAttribute('content', '#ffffff');
@@ -40,7 +40,7 @@
 		isLastActiveTab,
 		isApp,
 		appInfo,
-		toolServers,
+		toolServers
 	} from '$lib/stores';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
@@ -728,7 +728,13 @@
 {/if}
 
 <Toaster
-	theme={'light'}
+	theme={$theme.includes('dark')
+		? 'dark'
+		: $theme === 'system'
+			? window.matchMedia('(prefers-color-scheme: dark)').matches
+				? 'dark'
+				: 'light'
+			: 'light'}
 	richColors
 	position="top-right"
 />


### PR DESCRIPTION
## Problem
- Import error: `themeChangeHandler` from General.svelte was causing module resolution issues
- Theme required 2 page refreshes to apply - first refresh set the variable, second applied it

## Solution
- Removed problematic import of `themeChangeHandler` from General.svelte component
- Replaced with direct theme store and localStorage setting
- Moved theme initialization to execute immediately before onMount lifecycle
- Added DOM manipulation to apply theme attributes and meta theme color instantly

## Changes
- Set `theme.set('light')` and `localStorage.setItem('theme', 'light')` at component initialization
- Apply `document.documentElement.setAttribute('theme', 'light')` immediately
- Set meta theme color to `#ffffff` for light theme
- Added browser environment check for DOM operations

## Result
- ✅ Eliminates module resolution error
- ✅ Theme applies correctly on first page load
- ✅ No more refresh required to see theme changes
- ✅ Maintains same functionality with cleaner implementation