### PR TITLE
Fix error: failed to open file /root/.cache/uv/sdists-v9/.git: Permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,8 @@ RUN if [ "$USE_CUDA" = "true" ]; then \
     uv run python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
     uv run python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])" && \
     uv run python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])" && \
-    chown -R $UID:$GID /app/backend/data/ || true
+    chown -R $UID:$GID /app/backend/data/ && \
+    chown -R $UID:$GID /root/.cache/;
 
 # copy embedding weight from build
 # RUN mkdir -p /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2


### PR DESCRIPTION
The Pull Request https://github.com/etalab-ia/albert-conversation/pull/98 caused the following bug when starting Docker image `albert-conversation/app`:

```
error: failed to open file /root/.cache/uv/sdists-v9/.git: Permission denied (os error 13)
```

Why? Because the Docker image is executed in production with parameters UID=1001 and GID=1001

This commit changes the owner of `/root/.cache/*` files during image build.

Reference: https://linear.app/albert-conversation/issue/ALB-164/
