### PR TITLE
Fix error: error: failed to remove file `/app/.venv/lib/python3.11/site-packages/../../../bin/open-webui`: Permission denied (os error 13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN if [ "$USE_CUDA" = "true" ]; then \
     uv run python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
     uv run python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])" && \
     uv run python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])" && \
-    chown -R $UID:$GID /app/backend/data/ && \
+    chown -R $UID:$GID /app/ && \
     chown -R $UID:$GID /root/.cache/;
 
 # copy embedding weight from build


### PR DESCRIPTION
This commit follows 29a983f34ebff73e9ced9aa73efbae380c952488

The Pull Request https://github.com/etalab-ia/albert-conversation/pull/98 caused the following bug when starting Docker image `albert-conversation/app`:

```
error: failed to remove file `/app/.venv/lib/python3.11/site-packages/../../../bin/open-webui`: Permission denied (os error 13)
```

Why? Because the Docker image is executed in production with parameters `UID=100`1 and `GID=1001`.

This commit changes the owner of /app/* files during image build.

Reference: https://linear.app/albert-conversation/issue/ALB-164/

