### PR TITLE
Anthonyjacquelin78/alb 161 enforce model selected by default to taches simples

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -60,6 +60,23 @@
 	let selectedModel = '';
 	$: selectedModel = items.find((item) => item.value === value) ?? '';
 
+	// Auto-select "albert-small" if available, or first model if no value is set
+	$: if (items.length > 0 && !value) {
+		const albertSmallModel = items.find((item) => 
+			item.value === 'albert-small' || 
+			item.model?.name === 'albert-small' ||
+			item.label.toLowerCase().includes('albert-small')
+		);
+		
+		if (albertSmallModel) {
+			value = albertSmallModel.value;
+			dispatch('change', albertSmallModel.value);
+		} else if (items.length > 0) {
+			value = items[0].value;
+			dispatch('change', items[0].value);
+		}
+	}
+
 	let searchValue = '';
 
 	let selectedTag = '';


### PR DESCRIPTION
1. **Checks for "albert-small"**

2. **Fallback to first model in the list**

4. **Only when no value is set**: The logic only runs when `items.length > 0 && !value`, ensuring it doesn't override an explicitly selected model

5. **Dispatches change event**: When a model is automatically selected, it dispatches a 'change' event to notify the parent component

This solution will automatically set "albert-small" as the selected model when the component loads (if available), or fall back to the first model in the list. The selection only happens when no model is currently selected, preserving any explicit user choices.